### PR TITLE
Fix generation of 2+ order chains

### DIFF
--- a/src/markov/core.clj
+++ b/src/markov/core.clj
@@ -85,7 +85,7 @@
          nil
          (letfn [(lazy-walk [last-state]
                    (let [next-state (take-from-probs (get probs last-state))
-                         next-args  (conj (rest last-state) next-state)]
+                         next-args  (conj (vec (rest last-state)) next-state)]
                      (if (nil? next-state)
                        nil ; cons _ nil = (_)
                        (cons next-state (lazy-seq (lazy-walk next-args))))))]

--- a/src/markov/core.clj
+++ b/src/markov/core.clj
@@ -77,7 +77,7 @@
   For example, ABACAD -> if we ever get to D, we end."
   ([probs] (generate-walk (first (rand-nth (seq probs)))
                               probs))
-  ([start probs] 
+  ([start probs]
    (if (not (sequential? start))
      (generate-walk [start] probs)
      (let [order (count (first (first (seq probs))))]

--- a/test/markov/core_test.clj
+++ b/test/markov/core_test.clj
@@ -90,7 +90,7 @@
   (is (= '(:a :b)
          (take 2 (generate-walk [:a :b] (build-from-coll [:a :b :c :d :a :b :c]))))
       "More starting values are possible")
-         
+
   (is (= :d
          (last (generate-walk (build-from-coll [:a :b :a :c :a :d]))))
       "Halts if gets to state from which it didn't ever continue"))

--- a/test/markov/core_test.clj
+++ b/test/markov/core_test.clj
@@ -93,4 +93,10 @@
 
   (is (= :d
          (last (generate-walk (build-from-coll [:a :b :a :c :a :d]))))
-      "Halts if gets to state from which it didn't ever continue"))
+      "Halts if gets to state from which it didn't ever continue")
+
+  (is (= [:a :b :c :d :e :f] (generate-walk :a (build-from-coll 1 [:a :b :c :d :e :f])))
+      "Walks to the end of 1st order, one-way coll")
+
+  (is (= [:d :c :f :g :f] (generate-walk [:d :c] (build-from-coll 2 [:g :c :d :c :f :g :f])))
+      "Walks to the end of 2nd order, one-way coll"))


### PR DESCRIPTION
`(conj (rest last-state) next-state)` was giving `(:b :a)` instead of `[:a :b]` because `rest` returns seq, not a vec. This was breaking generation of 2+ order chains.
